### PR TITLE
Shapefile upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ inst/doc
 rsconnect
 .Rprofile
 shiny_bookmarks
+A2SIT_data_input_template.xlsx

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: A2SIT
 Title: Admin2 Severity Index Tool
-Version: 0.2.0
+Version: 0.3.0
 Authors@R: 
     person("William", "Becker", , "william.becker@bluefoxdata.eu", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6467-4472"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Imports:
     stats,
     unhcrshiny (>= 0.1.0),
     utils,
-    webshot
+    webshot2
 Suggests: 
     knitr,
     markdown,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,6 +41,7 @@ Imports:
     webshot
 Suggests: 
     knitr,
+    markdown,
     rmarkdown,
     spelling,
     testthat (>= 3.0.0)

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -9,6 +9,8 @@
 #' @import shiny
 app_server <- function(input, output, session) {
 
+  # set max file upload to 30MB
+  options(shiny.maxRequestSize=30*1024^2)
 
   # Shared variables --------------------------------------------------------
 
@@ -25,7 +27,8 @@ app_server <- function(input, output, session) {
     l_analysis = NULL,
     l_analysis_f = NULL,
     new_to_welcome_tab = TRUE,
-    new_to_map_tab = TRUE
+    new_to_map_tab = TRUE,
+    user_geom = FALSE
   )
 
   # Modules -----------------------------------------------------------------

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -18,29 +18,31 @@ app_server <- function(input, output, session) {
   # within any module and don't need to be passed back out.
 
   coin <- reactiveVal(NULL)
-  coin_full <- reactiveVal(NULL)
+  coin_full <- reactiveVal(NULL) # coin with no indicators removed
+  df_geom <- reactiveVal(NULL) # geometry for mapping
   r_shared <- reactiveValues(
-    ISO3 = NULL, # country of the data
+    ISO3 = NULL, # country of the data (if not user geom)
     profile_unit = NULL, # unit to view in profiles
     results_built = FALSE, # whether results (up to aggregation) built
     scenarios = NULL, # list of saved scenarios for comparison
     l_analysis = NULL,
     l_analysis_f = NULL,
     new_to_welcome_tab = TRUE,
-    new_to_map_tab = TRUE,
-    user_geom = FALSE
+    user_geom = FALSE, # whether user has uploaded their own geometry,
+    uCode_col = "adm2_source_code", # col name in geometry df referring to uCode
+    uName_col = "gis_name" # col name in geometry df referring to uName
   )
 
   # Modules -----------------------------------------------------------------
 
   welcome_server("id_welcome", session, input, r_shared)
-  input_server("id_input", coin, coin_full, r_shared)
+  input_server("id_input", coin, coin_full, r_shared, df_geom)
   analysis_server("id_analysis", coin, coin_full, input, r_shared)
-  results_server("id_results", coin, coin_full, input, session, r_shared)
+  results_server("id_results", coin, coin_full, input, session, r_shared, df_geom)
   profiles_server("id_profiles", coin, coin_full, input, r_shared)
   scenarios_server("id_scenarios", coin, input, r_shared)
   compare_units_server("id_compare_units", coin, input, r_shared)
-  map_server("id_map", coin, input, r_shared)
+  map_server("id_map", coin, input, r_shared, df_geom)
 
   # Exports -----------------------------------------------------------------
 

--- a/R/f_input.R
+++ b/R/f_input.R
@@ -23,17 +23,23 @@
 #'
 #' @param file_path path to the excel file where we have the raw data
 #' @param ISO3 ISO3 code of country to which the data belongs, e.g. `"GTM"`
+#' @param df_geom sf-class geometry data frame (used to cross check input codes)
+#' @param uCode_col Column name of `df_geom` which is used as unit codes.
 #'
 #' @return coin-class object
 #'
 #' @export
-f_data_input <- function(file_path, ISO3, df_geom, uCode_col){
+f_data_input <- function(file_path, df_geom, ISO3 = NULL, uCode_col = NULL){
 
   # Checks ----
 
   if(!is.null(ISO3)){
     valid_ISOs <- get_cached_countries()
     stopifnot(ISO3 %in% valid_ISOs)
+  }
+
+  if(is.null(uCode_col)){
+    uCode_col <- "adm2_source_code"
   }
 
   # Settings ----
@@ -255,6 +261,9 @@ f_print_coin <- function(coin){
 #' @param uName_col Column name in `df_geom` to use as uNames in COINr (could also
 #' be same as `uCode_col`).
 #' @param to_file_name Where to write the template file to.
+#' @param with_fake_data Logical: if `TRUE` the input template will also contain
+#' randomly-generated input data which can be used as a quick demo and for testing
+#' uploads of new shape files.
 #'
 #' @export
 f_generate_input_template <- function(df_geom = NULL, to_file_name = NULL,
@@ -334,7 +343,7 @@ populate_with_fake_data <- function(df_write){
     n_ind <- sample(3, 1)
     i_indexes <- 1:n_ind + i_index
 
-    cols2add <- matrix(runif(n_ind*n_unit), nrow = n_unit, ncol = n_ind) |>
+    cols2add <- matrix(stats::runif(n_ind*n_unit), nrow = n_unit, ncol = n_ind) |>
       as.data.frame()
     names(cols2add) <- paste0("ind_", i_indexes)
 

--- a/R/f_results.R
+++ b/R/f_results.R
@@ -426,7 +426,7 @@ f_save_map <- function(plt, file_name = "map.png"){
 
     # NOTE: webshot2 used for capture here because doesn't depend on phantomJS.
     # Although, this apparently only works for Chromium-based browsers.
-    webshot2::webshot(html_path, file = file_name, vwidth = 1600, vheight = 900, quiet = TRUE)
+    webshot2::webshot(html_path, file = file_name, quiet = TRUE, vwidth = 2000, vheight = 1300)
     unlink(html_path)
   }
 

--- a/R/f_results.R
+++ b/R/f_results.R
@@ -735,7 +735,7 @@ get_cached_countries <- function(){
 # For full selection see https://leaflet-extras.github.io/leaflet-providers/preview/index.html
 get_leaflet_map_providers <- function(){
 
-  full_list <- leaflet::providers
+  full_list <- leaflet::providers |> as.character()
 
   esri <- full_list[startsWith(full_list, "Esri.World")]
   carto <- full_list[startsWith(full_list, "CartoDB")]

--- a/R/f_results.R
+++ b/R/f_results.R
@@ -303,6 +303,10 @@ f_display_results_table <- function(coin, type = "scores", as_discrete = FALSE){
 #' @param line_weight Weight for lines
 #' @param line_type Type for lines: value from 1-4.
 #' @param legendposition Legend position argument passed to Leaflet
+#' @param uCode_col Column name of `df_geom` which corresponds to `uCode` in COINr
+#' @param uName_col Column name of `df_geom` which corresponds to `uName` in COINr
+#' @param map_base String specifying the base map tiles to use. Some valid inputs here
+#' can be found by calling `get_leaflet_map_providers()`.
 #'
 #' @return Leaflet map object
 #' @export
@@ -727,7 +731,11 @@ get_cached_countries <- function(){
 #ISO3s_2get <- c("ARG", "BLZ", "BRA", "BOL", "CHL", "COL", "CRI", "DOM", "ECU", "SLV", "GTM", "GUY", "HND", "MEX", "PAN", "PRY", "PER", "URY", "VEN")
 #Argentina,  Belize, Brazil, Bolivia, Chile, Colombia, Costa Rica, Dominican Republic, Ecuador, El Salvador, Guatemala, Guyana, Honduras, Mexico, Panama, Paraguay, Peru, Uruguay, Venezuela.
 
+# A selection of Leaflet map providers to use as options in the app.
+# For full selection see https://leaflet-extras.github.io/leaflet-providers/preview/index.html
 get_leaflet_map_providers <- function(){
+
+  full_list <- leaflet::providers
 
   esri <- full_list[startsWith(full_list, "Esri.World")]
   carto <- full_list[startsWith(full_list, "CartoDB")]

--- a/R/f_results.R
+++ b/R/f_results.R
@@ -294,7 +294,8 @@ f_display_results_table <- function(coin, type = "scores", as_discrete = FALSE){
 #'
 #' @param coin The coin
 #' @param iCode iCode of indicator/aggregate to plot
-#' @param ISO3 Country of the data to plot
+#' @param df_geom Geometry data frame of "sf" class specifying map polygons. Must
+#' match uCodes found in coin.
 #' @param as_discrete If `TRUE`, plots severity categories.
 #' @param bin_colours Vector of colours to use on discrete palette if `as_discrete = TRUE`
 #' @param poly_opacity Opacity for polygons: value between 0 and 1
@@ -306,21 +307,16 @@ f_display_results_table <- function(coin, type = "scores", as_discrete = FALSE){
 #' @return Leaflet map object
 #' @export
 #'
-f_plot_map <- function(coin, iCode, ISO3, as_discrete = TRUE, bin_colours = NULL,
+f_plot_map <- function(coin, iCode, df_geom, uCode_col = NULL, uName_col = NULL,
+                       as_discrete = TRUE, bin_colours = NULL,
                        poly_opacity = 0.7, line_colour = "white", line_weight = 2,
-                       line_type = "3", legendposition = "bottomright"){
+                       line_type = "3", legendposition = "bottomright", map_base = NULL){
 
-  available_ISO3s <- get_cached_countries()
+  stopifnot(inherits(df_geom, "sf"))
 
-  if(ISO3 %nin% available_ISO3s){
-    stop("Cannot render map because geometry for country ", ISO3,
-         " not available in inst/geom. Run f_get_admin2_boundaries() to get",
-         " and store the required file.")
+  if(is.null(map_base)){
+    map_base <- "CartoDB.Positron"
   }
-
-  # get geom
-  admin2_geom <- system.file("geom", paste0(ISO3,".RDS"), package = "A2SIT") |>
-    readRDS()
 
   # find dset
   dset_plot <- get_plot_dset(coin, iCode)
@@ -340,7 +336,7 @@ f_plot_map <- function(coin, iCode, ISO3, as_discrete = TRUE, bin_colours = NULL
   }
 
   # merge into shape df
-  admin2_geom <- merge(admin2_geom, df_plot, by.x = "adm2_source_code", by.y = "uCode") |>
+  df_geom <- merge(df_geom, df_plot, by.x = uCode_col, by.y = "uCode") |>
     sf::st_as_sf()
 
   # Colours and labels ------------------------------------------------------
@@ -359,17 +355,17 @@ f_plot_map <- function(coin, iCode, ISO3, as_discrete = TRUE, bin_colours = NULL
   }
 
   labels <- paste0(
-    "<strong>", admin2_geom$gis_name, "</strong><br/>",
-    round(admin2_geom$Indicator, 2), " (rank ", admin2_geom$Rank,")"
+    "<strong>", df_geom[[uName_col]], "</strong><br/>",
+    round(df_geom$Indicator, 2), " (rank ", df_geom$Rank,")"
   ) |>
     lapply(htmltools::HTML)
 
 
   # Plot --------------------------------------------------------------------
 
-  mp <- leaflet::leaflet(admin2_geom) |>
-    leaflet::addProviderTiles("CartoDB.Positron") |>
-    leaflet::addPolygons(layerId = ~adm2_source_code,
+  mp <- leaflet::leaflet(df_geom) |>
+    leaflet::addProviderTiles(map_base) |>
+    leaflet::addPolygons(layerId = ~get(uCode_col),
                          fillColor = ~pal(Indicator),
                          weight = line_weight,
                          opacity = 1,
@@ -730,3 +726,11 @@ get_cached_countries <- function(){
 # Codes cached so far (or tried to...!)
 #ISO3s_2get <- c("ARG", "BLZ", "BRA", "BOL", "CHL", "COL", "CRI", "DOM", "ECU", "SLV", "GTM", "GUY", "HND", "MEX", "PAN", "PRY", "PER", "URY", "VEN")
 #Argentina,  Belize, Brazil, Bolivia, Chile, Colombia, Costa Rica, Dominican Republic, Ecuador, El Salvador, Guatemala, Guyana, Honduras, Mexico, Panama, Paraguay, Peru, Uruguay, Venezuela.
+
+get_leaflet_map_providers <- function(){
+
+  esri <- full_list[startsWith(full_list, "Esri.World")]
+  carto <- full_list[startsWith(full_list, "CartoDB")]
+
+  c(carto, esri, "OpenStreetMap.Mapnik")
+}

--- a/R/f_results.R
+++ b/R/f_results.R
@@ -417,7 +417,16 @@ f_save_map <- function(plt, file_name = "map.png"){
   } else {
     html_path <- paste0(tempdir(), "\\temp_map.html")
     htmlwidgets::saveWidget(plt, file = html_path)
-    webshot::webshot(html_path, file = file_name)
+
+    # Have to convert backslashes to forward slashes otherwise webshot breaks
+    # To be seen how this behaves on different platforms.
+    if(grepl("\\\\", html_path)){
+      html_path <- gsub("\\\\", "/", html_path)
+    }
+
+    # NOTE: webshot2 used for capture here because doesn't depend on phantomJS.
+    # Although, this apparently only works for Chromium-based browsers.
+    webshot2::webshot(html_path, file = file_name, vwidth = 1600, vheight = 900, quiet = TRUE)
     unlink(html_path)
   }
 

--- a/R/f_shapefile_handling.R
+++ b/R/f_shapefile_handling.R
@@ -13,9 +13,16 @@ geojson_to_sf <- function(file_path){
 }
 
 # A series of checks and possible fixes for geometry data frame uploaded by user
-check_and_fix_sf <- function(df_geom, uCode_col, uName_col){
+check_and_fix_sf <- function(df_geom, uCode_col = NULL, uName_col = NULL){
 
   stopifnot(inherits(df_geom, "sf"))
+
+  if(is.null(uCode_col)){
+    uCode_col <- "adm2_source_code"
+  }
+  if(is.null(uName_col)){
+    uName_col <- "gis_name"
+  }
 
   if(uCode_col %nin% names(df_geom)){
     stop("String specified as 'uCode' is not found among column names of uploaded geometry table.")
@@ -43,8 +50,8 @@ check_and_fix_sf <- function(df_geom, uCode_col, uName_col){
   # should not contain spaces
   spaces <- grepl(" ", uCodes)
   if(any(spaces)){
-    uCodes <- gsub(" ", "", uCodes)
-    warning("Spaces detected in entries of column '", uCode_col, "' - these are not allowed and have been removed.")
+    uCodes <- gsub(" ", "_", uCodes)
+    warning("Spaces detected in entries of column '", uCode_col, "' - these have been substituted with '_'.")
   }
 
   # should not start with a number
@@ -58,4 +65,30 @@ check_and_fix_sf <- function(df_geom, uCode_col, uName_col){
 
   df_geom
 
+}
+
+
+sample_geom_column <- function(df_geom, col_selected, max_length = 30){
+
+  stopifnot(col_selected %in% names(df_geom))
+
+  str_out <- df_geom[[col_selected]]
+
+  if(!(is.character(str_out) || is.numeric(str_out))){
+    return("Invalid column selected (not numeric/character)")
+  }
+  if(all(str_out == "") || all(is.na(str_out))){
+    return("Empty column selected")
+  }
+
+  str_out <- head(str_out, 3) |> toString(max_length)
+  str_out <- paste0("Sample: ", str_out)
+
+  str_out
+}
+
+# adds a column 'AppGeneratedCode'
+add_uCode_col <- function(df_geom){
+  df_geom$AppGeneratedCode <- paste0("r", sprintf("%04d", 1:nrow(df_geom)))
+  df_geom
 }

--- a/R/f_shapefile_handling.R
+++ b/R/f_shapefile_handling.R
@@ -81,7 +81,7 @@ sample_geom_column <- function(df_geom, col_selected, max_length = 30){
     return("Empty column selected")
   }
 
-  str_out <- head(str_out, 3) |> toString(max_length)
+  str_out <- utils::head(str_out, 3) |> toString(max_length)
   str_out <- paste0("Sample: ", str_out)
 
   str_out

--- a/R/f_shapefile_handling.R
+++ b/R/f_shapefile_handling.R
@@ -1,0 +1,61 @@
+# reads a geojson and outputs as sf
+geojson_to_sf <- function(file_path){
+
+  tryCatch({
+      sf::st_read(file_path)
+    },
+    error = function(e){
+      message("Geometry file not successfully read/converted by the app.")
+      print(e)
+    }
+  )
+
+}
+
+# A series of checks and possible fixes for geometry data frame uploaded by user
+check_and_fix_sf <- function(df_geom, uCode_col, uName_col){
+
+  stopifnot(inherits(df_geom, "sf"))
+
+  if(uCode_col %nin% names(df_geom)){
+    stop("String specified as 'uCode' is not found among column names of uploaded geometry table.")
+  }
+  if(uName_col %nin% names(df_geom)){
+    stop("String specified as 'uName' is not found among column names of uploaded geometry table.")
+  }
+
+  uCodes <- df_geom[[uCode_col]]
+  uNames <- df_geom[[uName_col]]
+
+  stopifnot(is.character(uCodes),
+            is.character(uNames),
+            !anyNA(uCodes),
+            !anyNA(uNames))
+
+  # check duplicates and rename
+  if(anyDuplicated(uCodes) > 1){
+    # rename duplicates
+    uCodes <-  make.unique(uCodes)
+    warning("Duplicate codes detected in column '", uCode_col, "' - these have been renamed to be unique.")
+  }
+
+  # check numbers at beginning
+  # should not contain spaces
+  spaces <- grepl(" ", uCodes)
+  if(any(spaces)){
+    uCodes <- gsub(" ", "", uCodes)
+    warning("Spaces detected in entries of column '", uCode_col, "' - these are not allowed and have been removed.")
+  }
+
+  # should not start with a number
+  num_start <- substring(uCodes, 1,1) %in% 0:9
+  if(any(num_start)){
+    uCodes <- paste0("u_", uCodes)
+    warning("Some entries in column '", uCode_col, "' begin with a number. These have been adjusted to avoid processing difficulties.")
+  }
+
+  df_geom[[uCode_col]] <- uCodes
+
+  df_geom
+
+}

--- a/R/mod_analysis.R
+++ b/R/mod_analysis.R
@@ -93,11 +93,11 @@ analysis_UI <- function(id) {
           icon = icon("gear"),
           width = 40,
           p("Select an indicator - you can also type to search in this box."),
-          selectInput(NS(id, "scat_v2"), label = "Plot against", choices = c("tmp_999")),
-          shinyWidgets::prettySwitch(NS(id, "scat_trend"), label = "Trendline"),
-          shinyWidgets::prettySwitch(NS(id, "scat_logx"), label = "Log X"),
-          shinyWidgets::prettySwitch(NS(id, "scat_logy"), label = "Log Y"),
-          shinyWidgets::prettySwitch(NS(id, "scat_details"), label = "Show stats", value = FALSE)
+          selectInput(NS(id, "scat_v2"), label = "Plot against", choices = c("tmp_999"), width = "90%"),
+          shinyWidgets::switchInput(NS(id, "scat_trend"), label = "Trend-line", size = "small", width = "100%", labelWidth = "120px"),
+          shinyWidgets::switchInput(NS(id, "scat_logx"), label = "Log X", size = "small", width = "100%", labelWidth = "120px"),
+          shinyWidgets::switchInput(NS(id, "scat_logy"), label = "Log Y", size = "small", width = "100%", labelWidth = "120px"),
+          shinyWidgets::switchInput(NS(id, "scat_details"), label = "Stats", size = "small", width = "100%", labelWidth = "120px")
         ),
         plotly::plotlyOutput(NS(id, "scatter_plot"))
       )

--- a/R/mod_input.R
+++ b/R/mod_input.R
@@ -44,7 +44,8 @@ input_UI <- function(id) {
             h4("2. Download country template"),
             p("Download the template for the selected country:"),
             downloadButton(NS(id, "download_country_template"), "Download country template"),
-            shinyWidgets::prettySwitch(NS(id, "gen_fake_data"), label = "With fake data", value = FALSE, inline = TRUE),
+            br(),br(),
+            shinyWidgets::prettySwitch(NS(id, "gen_fake_data"), label = "Populate with fake data", value = FALSE),
             hr(),
 
             h4("3. Upload your data"),

--- a/R/mod_map.R
+++ b/R/mod_map.R
@@ -26,14 +26,24 @@ map_UI <- function(id) {
         #h4("Styling"),
         numericInput(NS(id, "map_opacity"), label = "Opacity", value = 0.7, min = 0.1, max = 1, step = 0.1, width = "50%"),
 
-        textInput(NS(id, "map_linecolour"), label = "Line colour", placeholder = "HEX code", width = "50%", value = "white"),
-        numericInput(NS(id, "map_lineweight"), label = "Line weight", value = 2, min = 0.5, max = 5, step = 0.5, width = "50%"),
+        fluidRow(
+          col_6(textInput(NS(id, "map_linecolour"), label = "Line colour", placeholder = "HEX code", width = "90%", value = "white")),
+          col_6(numericInput(NS(id, "map_lineweight"), label = "Line weight", value = 2, min = 0.5, max = 5, step = 0.5, width = "90%"))
+        ),
 
         selectInput(NS(id, "map_linetype"), label = "Line type",
                           choices = list(Solid = 1, Dot = 2, Dash = 4),  width = "50%"),
         selectInput(NS(id, "map_base"), label = "Map base tiles", choices = get_leaflet_map_providers(), width = "70%"),
 
         actionButton(NS(id, "plot_map_button"), label = "Plot"),
+        hr(),
+
+        fluidRow(
+          col_6(downloadButton(NS(id, "download_map"), label = "Download map")),
+          col_6(selectInput(NS(id, "download_map_filetype"), label = NULL,
+                            choices = c("png", "jpeg", "html"),
+                            width = "80%"))
+        ),
 
         tags$style("z-index: 2000")
 
@@ -119,23 +129,23 @@ map_server <- function(id, coin, parent_input, r_shared, df_geom) {
 
     })
 
-    # # user map (for download)
-    # user_map <- reactive({
-    #   leaflet::setView(
-    #     current_map(),
-    #     lng = input$map_center$lng,
-    #     lat = input$map_center$lat,
-    #     zoom = input$map_zoom
-    #   )
-    # })
-    #
-    # # download map
-    # output$download_map <- downloadHandler(
-    #   filename = function(){paste0("A2SIT_map.", input$download_map_filetype)},
-    #   content = function(file) {
-    #     f_save_map(plt = user_map(), file_name = file)
-    #   }
-    # )
+    # user map (for download)
+    user_map <- reactive({
+      leaflet::setView(
+        current_map(),
+        lng = input$map_center$lng,
+        lat = input$map_center$lat,
+        zoom = input$map_zoom
+      )
+    })
+
+    # download map
+    output$download_map <- downloadHandler(
+      filename = function(){paste0("A2SIT_map.", input$download_map_filetype)},
+      content = function(file) {
+        f_save_map(plt = user_map(), file_name = file)
+      }
+    )
 
   })
 

--- a/R/mod_map.R
+++ b/R/mod_map.R
@@ -20,6 +20,7 @@ map_UI <- function(id) {
                     choices = NULL, width = "95%"),
         #h4("Colours"),
         numericInput(NS(id, "n_colours"), label = "Number of colours", 4, min = 2, max = 10, step = 1, width = "50%"),
+        "Note: the first colour corresponds to the lowest scores.",
         uiOutput(NS(id, "mapcolour_dropdowns")),
 
         #h4("Styling"),

--- a/R/mod_profiles.R
+++ b/R/mod_profiles.R
@@ -29,6 +29,7 @@ profiles_UI <- function(id) {
           placement = "top"
         ),
         width = 12, status = "info",
+        "Severity scores and ranks are colour coded so that a darker red indicates a higher value.",
         DT::dataTableOutput(NS(id, "df_indicators")))
     ),
     column(
@@ -46,8 +47,8 @@ profiles_UI <- function(id) {
           id = "radar_sidebar",
           icon = icon("gear"),
           width = 40,
-          selectInput(NS(id, "radar_group"), label = "Show group", choices = NULL),
-          shinyWidgets::prettySwitch(NS(id, "plot_radar"), label = "Toggle radar/table", value = TRUE)
+          selectInput(NS(id, "radar_group"), label = "Show group", choices = NULL, width = "90%"),
+          shinyWidgets::switchInput(NS(id, "plot_radar"), label = "Toggle radar/table", size = "small", width = "100%", labelWidth = "200px")
         ),
         plotly::plotlyOutput(NS(id, "radar_chart")),
         DT::dataTableOutput(NS(id, "radar_table"))

--- a/R/mod_results.R
+++ b/R/mod_results.R
@@ -104,6 +104,7 @@ results_UI <- function(id) {
             value = FALSE)
         ),
         uiOutput(NS(id, "weight_sliders")),
+        "Adjust the degree of compensation between indicators when calculating index scores.",
         selectInput(NS(id, "agg_method"), label = "Scenarios",
                     choices = list("Scenario 1: High compensation" = "a_amean",
                                    "Scenario 2: Medium compensation" = "a_gmean",
@@ -139,6 +140,7 @@ results_UI <- function(id) {
         ),
         width = 3, status = "success",
 
+        "Export the map as an image file and export the results to Excel or R.",
         h4(icon("download"), " Download map"),
         div(style = "display: flex; justify-content: space-between;",
             downloadLink(NS(id, "download_map"), label = "Click to download", style = "text-align: right;"),

--- a/R/mod_results.R
+++ b/R/mod_results.R
@@ -186,7 +186,7 @@ results_UI <- function(id) {
 
 }
 
-results_server <- function(id, coin, coin_full, parent_input, parent_session, r_shared) {
+results_server <- function(id, coin, coin_full, parent_input, parent_session, r_shared, df_geom) {
 
   moduleServer(id, function(input, output, session) {
 
@@ -262,9 +262,14 @@ results_server <- function(id, coin, coin_full, parent_input, parent_session, r_
       req(coin())
       req(results_exist(coin()))
       req(input$plot_icode)
+      req(df_geom())
 
-      f_plot_map(coin(), ISO3 = r_shared$ISO3,
-                 iCode = input$plot_icode, as_discrete = as.logical(input$as_discrete))
+      f_plot_map(
+        coin(),
+        uCode_col = r_shared$uCode_col,
+        uName_col = r_shared$uName_col,
+        df_geom = df_geom(),
+        iCode = input$plot_icode, as_discrete = as.logical(input$as_discrete))
     })
 
     # Plot map

--- a/R/mod_results.R
+++ b/R/mod_results.R
@@ -145,7 +145,7 @@ results_UI <- function(id) {
         div(style = "display: flex; justify-content: space-between;",
             downloadLink(NS(id, "download_map"), label = "Click to download", style = "text-align: right;"),
             selectInput(NS(id, "download_map_filetype"), label = NULL,
-                        choices = c("png", "pdf", "jpeg", "html"),
+                        choices = c("png", "jpeg", "html"),
                         width = "40%")
         ),
 

--- a/R/mod_welcome.R
+++ b/R/mod_welcome.R
@@ -77,16 +77,11 @@ welcome_server <- function(id, parent_session, parent_input, r_shared) {
       req(parent_input$tab_selected == "welcome")
       if(r_shared$new_to_welcome_tab){
 
-        shinyWidgets::sendSweetAlert(
-          session = session,
-          title = "Welcome", html = TRUE,
-
-          text = tags$div(
-            "Welcome to the A2SIT app. If this is your first time here, please take the ",
-            actionLink(NS(id, "launch_tour"), label = "quick tour.")
-          ),
-          btn_labels = "Close",
-          type = "info"
+        showNotification(
+          ui = "Welcome to the A2SIT app. If this is your first time here, please take the quick tour.",
+          action = actionLink(NS(id, "launch_tour"), label = "Take tour"),
+          duration = 10,
+          type = "message"
         )
         # set so that tour not launched if return to this tab
         r_shared$new_to_welcome_tab <- FALSE

--- a/R/run_app.R
+++ b/R/run_app.R
@@ -6,14 +6,14 @@
 #' @importFrom golem with_golem_options
 #' @export
 run_app <- function(...) {
-  # check if phantomJS installed
-  if(!webshot::is_phantomjs_installed()){
-    webshot::install_phantomjs() |> suppressMessages()
-    # check if succeeded
-    if(!webshot::is_phantomjs_installed()){
-      message("Cannot install phantomJS for some reason. This means that map downloads will be disabled.")
-    }
-  }
+  # # check if phantomJS installed
+  # if(!webshot::is_phantomjs_installed()){
+  #   webshot::install_phantomjs() |> suppressMessages()
+  #   # check if succeeded
+  #   if(!webshot::is_phantomjs_installed()){
+  #     message("Cannot install phantomJS for some reason. This means that map downloads will be disabled.")
+  #   }
+  # }
 
   with_golem_options(
     app = shinyApp(ui = app_ui, server = app_server, enableBookmarking = "server"),

--- a/man/f_data_input.Rd
+++ b/man/f_data_input.Rd
@@ -4,12 +4,16 @@
 \alias{f_data_input}
 \title{Data input}
 \usage{
-f_data_input(file_path, ISO3, df_geom, uCode_col)
+f_data_input(file_path, df_geom, ISO3 = NULL, uCode_col = NULL)
 }
 \arguments{
 \item{file_path}{path to the excel file where we have the raw data}
 
+\item{df_geom}{sf-class geometry data frame (used to cross check input codes)}
+
 \item{ISO3}{ISO3 code of country to which the data belongs, e.g. \code{"GTM"}}
+
+\item{uCode_col}{Column name of \code{df_geom} which is used as unit codes.}
 }
 \value{
 coin-class object

--- a/man/f_data_input.Rd
+++ b/man/f_data_input.Rd
@@ -4,7 +4,7 @@
 \alias{f_data_input}
 \title{Data input}
 \usage{
-f_data_input(file_path, ISO3)
+f_data_input(file_path, ISO3, df_geom, uCode_col)
 }
 \arguments{
 \item{file_path}{path to the excel file where we have the raw data}

--- a/man/f_generate_input_template.Rd
+++ b/man/f_generate_input_template.Rd
@@ -4,14 +4,27 @@
 \alias{f_generate_input_template}
 \title{Generate Excel template for input data, for specified country}
 \usage{
-f_generate_input_template(ISO3, to_file_name = NULL)
+f_generate_input_template(
+  df_geom = NULL,
+  to_file_name = NULL,
+  uCode_col = NULL,
+  uName_col = NULL,
+  with_fake_data = FALSE
+)
 }
 \arguments{
-\item{ISO3}{Valid ISO3 code with geometry available in inst/geom}
+\item{df_geom}{Data frame of "sf" class which contains geometry for mapping the data,
+and associated codes and names of each geographical area (region/country).}
 
-\item{to_file_name}{Where to write to}
+\item{to_file_name}{Where to write the template file to.}
+
+\item{uCode_col}{Column name in \code{df_geom} to use as uCodes in COINr. Must contain
+unique codes, not starting with number.}
+
+\item{uName_col}{Column name in \code{df_geom} to use as uNames in COINr (could also
+be same as \code{uCode_col}).}
 }
 \description{
 Writes codes and names of Admin2 regions to an Excel template, for a specified
-country.
+country. Takes an sf-class data frame and extracts codes and names from it.
 }

--- a/man/f_generate_input_template.Rd
+++ b/man/f_generate_input_template.Rd
@@ -23,6 +23,10 @@ unique codes, not starting with number.}
 
 \item{uName_col}{Column name in \code{df_geom} to use as uNames in COINr (could also
 be same as \code{uCode_col}).}
+
+\item{with_fake_data}{Logical: if \code{TRUE} the input template will also contain
+randomly-generated input data which can be used as a quick demo and for testing
+uploads of new shape files.}
 }
 \description{
 Writes codes and names of Admin2 regions to an Excel template, for a specified

--- a/man/f_plot_map.Rd
+++ b/man/f_plot_map.Rd
@@ -7,14 +7,17 @@
 f_plot_map(
   coin,
   iCode,
-  ISO3,
+  df_geom,
+  uCode_col = NULL,
+  uName_col = NULL,
   as_discrete = TRUE,
   bin_colours = NULL,
   poly_opacity = 0.7,
   line_colour = "white",
   line_weight = 2,
   line_type = "3",
-  legendposition = "bottomright"
+  legendposition = "bottomright",
+  map_base = NULL
 )
 }
 \arguments{
@@ -22,7 +25,8 @@ f_plot_map(
 
 \item{iCode}{iCode of indicator/aggregate to plot}
 
-\item{ISO3}{Country of the data to plot}
+\item{df_geom}{Geometry data frame of "sf" class specifying map polygons. Must
+match uCodes found in coin.}
 
 \item{as_discrete}{If \code{TRUE}, plots severity categories.}
 

--- a/man/f_plot_map.Rd
+++ b/man/f_plot_map.Rd
@@ -28,6 +28,10 @@ f_plot_map(
 \item{df_geom}{Geometry data frame of "sf" class specifying map polygons. Must
 match uCodes found in coin.}
 
+\item{uCode_col}{Column name of \code{df_geom} which corresponds to \code{uCode} in COINr}
+
+\item{uName_col}{Column name of \code{df_geom} which corresponds to \code{uName} in COINr}
+
 \item{as_discrete}{If \code{TRUE}, plots severity categories.}
 
 \item{bin_colours}{Vector of colours to use on discrete palette if \code{as_discrete = TRUE}}
@@ -41,6 +45,9 @@ match uCodes found in coin.}
 \item{line_type}{Type for lines: value from 1-4.}
 
 \item{legendposition}{Legend position argument passed to Leaflet}
+
+\item{map_base}{String specifying the base map tiles to use. Some valid inputs here
+can be found by calling \code{get_leaflet_map_providers()}.}
 }
 \value{
 Leaflet map object

--- a/tests/testthat/test-data_input.R
+++ b/tests/testthat/test-data_input.R
@@ -3,7 +3,7 @@ test_that("f_data_input", {
   f_path <- system.file("A2SIT_data_input_template_GTM.xlsx", package = "A2SIT")
 
   # correct spec
-  df_geom <- readRDS(system.file("geom", "GTM.rds", package = "A2SIT"))
+  df_geom <- readRDS(system.file("geom", "GTM.RDS", package = "A2SIT"))
   coin <- f_data_input(f_path, df_geom = df_geom)
   expect_s3_class(coin, "coin")
 

--- a/tests/testthat/test-data_input.R
+++ b/tests/testthat/test-data_input.R
@@ -3,15 +3,16 @@ test_that("f_data_input", {
   f_path <- system.file("A2SIT_data_input_template_GTM.xlsx", package = "A2SIT")
 
   # correct spec
-  coin <- f_data_input(f_path, "GTM")
+  df_geom <- readRDS(system.file("geom", "GTM.rds", package = "A2SIT"))
+  coin <- f_data_input(f_path, df_geom = df_geom)
   expect_s3_class(coin, "coin")
 
-  # cached country, but wrong one
-  coin_error <- f_data_input(f_path, "ARG")
-  expect_null(coin_error)
-
-  # not cached country
-  expect_error(f_data_input(f_path, "XXX"), "ISO3 %in% valid_ISOs is not TRUE")
+  # # cached country, but wrong one
+  # coin_error <- f_data_input(f_path, "ARG")
+  # expect_null(coin_error)
+  #
+  # # not cached country
+  # expect_error(f_data_input(f_path, "XXX"), "ISO3 %in% valid_ISOs is not TRUE")
 
   # check that number of indicators and units agrees with manual inspection
   # Currently has 54 indicators, but 13 have no data so should be removed


### PR DESCRIPTION
The main addition here is enabling users to upload their own shape files to plot custom geometry in the app. At the moment, this supports geojson and json formats, which are read in using the `sf` package.

After reading in the geometry, the app generates a template for you to fill in based on codes specified by dropdown menus in the app.

Also added a switch to generate some fake data to populate the template - this was mainly for quick testing so could be removed if not useful in general.

Also added some potential fixes for deployment:

- Dependence on markdown package (odd bug with renv)
- Try using webshot2 package instead of webshot, to see if this can work on Posit Connect
- Download button in map tab
- Various minor tweaks to ui
